### PR TITLE
Hiányzó throw utasítás és billentyűelütés fix

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -30,7 +30,7 @@ public class TorpedoStore {
 
   public boolean fire(int numberOfTorpedos){
     if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount){
-      new IllegalArgumentException("numberOfTorpedos");
+      throw new IllegalArgumentException("numberOfTorpedos");
     }
 
     boolean success = false;

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -41,7 +41,7 @@ public class TorpedoStore {
 
     if (r >= FAILURE_RATE) {
       // successful firing
-      this.torpedoCount =- numberOfTorpedos;
+      this.torpedoCount -= numberOfTorpedos;
       success = true;
     } else {
       // simulated failure

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -56,6 +56,7 @@ public class TorpedoStore {
     return this.torpedoCount <= 0;
   }
 
+  // getter függvény
   public int getTorpedoCount() {
     return this.torpedoCount;
   }

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -48,6 +48,7 @@ public class TorpedoStore {
       success = false;
     }
 
+    // Return ha jó
     return success;
   }
 


### PR DESCRIPTION
Első commitban hiányzott egy `throw`, kivétel keletkezett csak nem lett eldobva. 
Második commitban pedig billentyűelütést fixeltem. `=-` -róő `-=`-re.